### PR TITLE
Adding a faster redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/*"
-  to = "https://briefcake.com/?ref=rssmailer.app"
+  to = "https://briefcake.com/rssmailer"
   status = 301
   force = true


### PR DESCRIPTION
merge after briefcake-landing project will take over root briefcake.com domain.